### PR TITLE
ODP TR-30 veriseti eklendi

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -214,6 +214,7 @@ Tieche, Nabil Ouerhani, Hazım Kemal Ekenel, Jean-Philippe Thiran)
 * [Artificial Characters Data Set](https://archive.ics.uci.edu/ml/datasets/Artificial+Characters)( H. Altay Guvenir et al, 1992)
 * [Turkish Natural Language Processing Toolkit- embedded in Zemberek](http://www.aliok.com.tr/projects/2014-10-02-trnltk.html)
 * [235.000 Turkish Product Reviews](https://github.com/fthbrmnby/turkish-text-data)
+* [ODP TR-30 Turkish Search Result Clustering Dataset](https://github.com/faraday/odp-tr30) (Ç. Çallı, 2010)
 ## VİDEO DERSLER
 ### Genel
 * [Ankara Deep Learning - Derin Öğrenme Etkinliği 1](https://youtu.be/K74rzKSsGs8) (Ferhat Kurt) {96 dakika}


### PR DESCRIPTION
Open Directory Project (ODP) üzerinden ODP 239 (İngilizce) http://search.fub.it/odp-239/ ile aynı prensiplerle Türkçe için derlenen ODP TR-30 veriseti eklendi.

Herhangi bir dil için ODP kullanarak derlemeyi oluşturan kod: https://github.com/faraday/odp-extract

Arama sonucu kümeleme çalışmalarında kullanılabilir. 

İlgili çalışma:

> C. Calli, G. Ucoluk, and T. Sehitoglu. Improving search result clustering by integrating semantic information from Wikipedia. MS Thesis, Middle East Technical University, Department of Computer Engineering, 2010.